### PR TITLE
Handle expired token by refreshing it with the RefreshToken cookie

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -24,7 +24,6 @@ func SetupRouter() *gin.Engine {
 
 func baseHandler(ctx *gin.Context) {
 	//1) check if the user has access token in the request
-	var accessToken = new(http.Cookie)
 	accessToken, err := ctx.Request.Cookie("Token")
 	if err != nil || accessToken.Expires.Unix() < time.Now().Unix() {
 		fmt.Println("Token is expired or not found")
@@ -48,8 +47,9 @@ func baseHandler(ctx *gin.Context) {
 		if data.RefreshToken == "" {
 			data.RefreshToken = tok
 		}
+		
 		ctx.SetCookie("RefreshToken", data.RefreshToken, 3600 * 24 * 7, "/", "", true, false)
-		accessToken.Value = data.AccessToken
+		accessToken = &http.Cookie{Value: data.AccessToken}
 	}
 	//how we have the token cookie being sent to us for every request
 	//use this token cookie, to make requests to the spotify api

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -24,6 +24,7 @@ func SetupRouter() *gin.Engine {
 
 func baseHandler(ctx *gin.Context) {
 	//1) check if the user has access token in the request
+	var accessToken = new(http.Cookie)
 	accessToken, err := ctx.Request.Cookie("Token")
 	if err != nil || accessToken.Expires.Unix() < time.Now().Unix() {
 		fmt.Println("Token is expired or not found")

--- a/token/token.go
+++ b/token/token.go
@@ -54,3 +54,24 @@ func GetTokenFromSpotify(code string) (tokenResponse, error) {
 	json.Unmarshal(body, responsePayload)
 	return *responsePayload, nil
 }
+
+func RefreshSpotifyToken(refreshToken string) (tokenResponse, error) {
+	form := url.Values{}
+	form.Add("grant_type", "refresh_token")
+	form.Add("refresh_token", refreshToken)
+	form.Add("client_id", config.EnvVariables.ClientId)
+	form.Add("client_secret", config.EnvVariables.ClientSecret)
+
+	resp, err := http.Post(config.EnvVariables.TokenUrl, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		return tokenResponse{}, err
+	}
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return tokenResponse{}, err
+	}
+	fmt.Println(string(buf))
+	data := new(tokenResponse)
+	json.Unmarshal(buf, data)
+	return *data, nil
+}

--- a/token/token.go
+++ b/token/token.go
@@ -70,7 +70,6 @@ func RefreshSpotifyToken(refreshToken string) (tokenResponse, error) {
 	if err != nil {
 		return tokenResponse{}, err
 	}
-	fmt.Println(string(buf))
 	data := new(tokenResponse)
 	json.Unmarshal(buf, data)
 	return *data, nil


### PR DESCRIPTION
This PR is an attempt to resolve https://github.com/chaithanyaMarripati/goSpotify/issues/15 by refreshing the token with the `RefreshToken` cookie set when the app initially got the necessary credentials. 


**Changes**
- Bumped the `RefreshToken` cookie to **a week**, because according to some sources (here's [one source](https://stackoverflow.com/a/30375475)) `RefreshToken` longevity is pretty much forever.  
- When the app successfully refreshes the token, check to see if Spotify has returned a `refresh_token` and set it to the current one, and renew the RefreshToken's cookie's expiration 

